### PR TITLE
feat: parse Cookie header into std::map, ignore invalid entries

### DIFF
--- a/Includes/HttpRequest.hpp
+++ b/Includes/HttpRequest.hpp
@@ -14,24 +14,25 @@ enum E_STATUS { Start_Line, Header, Body, END } ;
 
 class HttpRequest
 {
-    std::string                 r_buffer;
-    size_t                      r_current_body_size;
-    std::string                 r_method, r_url, r_version, r_query;
-    std::vector<S_Header>       r_header;
-    std::string                 r_body;
-    std::string                 r_host;
-    std::string                 r_content_type;
-    std::string                 path;
-    std::vector<std::string>    r_auto_index_files;
-    bool                        r_auto_index;
-    unsigned int                r_content_length;
-    bool                        r_has_content_length;
-    bool                        r_has_transfer_encoding;
-    ParseResult                 r_status_code;
-    E_STATUS                    r_read_status;
-    bool                        r_keep_alive;
-    ServerConfig                server ;
-    LocationConfig              location;
+    std::string                        r_buffer;
+    size_t                             r_current_body_size;
+    std::string                        r_method, r_url, r_version, r_query;
+    std::vector<S_Header>              r_header;
+    std::string                        r_body;
+    std::string                        r_host;
+    std::string                        r_content_type;
+    std::string                        path;
+    std::vector<std::string>           r_auto_index_files;
+    bool                               r_auto_index;
+    unsigned int                       r_content_length;
+    bool                               r_has_content_length;
+    bool                               r_has_transfer_encoding;
+    ParseResult                        r_status_code;
+    E_STATUS                           r_read_status;
+    bool                               r_keep_alive;
+    ServerConfig                       server ;
+    LocationConfig                     location;
+    std::map<std::string, std::string> r_cookies;
     public:
         HttpRequest( );
         ParseResult parse( std::string request );
@@ -43,6 +44,7 @@ class HttpRequest
         bool        validate_required_headers( ) ;
         ParseResult check_valid_path( ) ;
         ParseResult generateAutoindexHtml ( ) ;
+        void        handle_cookies();
         ~HttpRequest( );
 
         // Getters & Setters

--- a/Includes/includes.hpp
+++ b/Includes/includes.hpp
@@ -21,6 +21,7 @@
 #include <dirent.h>
 #include <signal.h>
 #include <ctime>
+#include <algorithm>
 
 
 enum ParseResult {

--- a/src/HttpRequest/parseRequest/r_header.cpp
+++ b/src/HttpRequest/parseRequest/r_header.cpp
@@ -9,6 +9,54 @@
     Returns true if the delimiter exists in 'request'; otherwise, returns false.
 */
 
+std::string trim(const std::string& str) {
+    std::size_t start = str.find_first_not_of(" \t\n\r");
+    std::size_t end = str.find_last_not_of(" \t\n\r");
+    return (start == std::string::npos) ? "" : str.substr(start, end - start + 1);
+}
+
+void        HttpRequest::handle_cookies( )
+{
+
+    std::vector<S_Header>::const_iterator it;
+    for (it = r_header.begin(); it != r_header.end(); it++)
+    {
+        if (it->key == "cookie")
+        {
+            break;
+        }
+        (void) it;
+    }
+    if ( it != r_header.end() )
+    {
+        std::string cookies = it->value;
+        while ( !cookies.empty() )
+        {
+            trim( cookies );
+            std::size_t index = cookies.find("=");
+            std::size_t sep = cookies.find(";");
+            if ( index == std::string::npos )
+                break;
+            sep = ( sep != std::string::npos ? sep : cookies.length() );
+            std::string key = trim( cookies.substr( 0, index ) );
+            std::string value = trim( cookies.substr( index + 1, sep - index - 1 ) );
+            if (!key.empty() && !value.empty())
+                r_cookies[key] = value;
+            cookies.erase(0, sep + 1);
+        }
+    }
+    // std::map<std::string, std::string>::iterator begin = r_cookies.begin();
+    // std::map<std::string, std::string>::iterator end = r_cookies.end();
+    // std::cout << "------------------------------------" <<std::endl;
+    // while (begin != end)
+    // {
+    //     std::cout << begin->first << "=" << begin->second << std::endl;
+    //     begin ++;
+    // }
+    // std::cout << "------------------------------------" <<std::endl;
+}
+
+
 bool HttpRequest::validate_required_headers( )
 {
     std::string required_headers[] = { "host", "user-agent", "accept", (r_method == "POST"? "content-type" : "END"), "END" };
@@ -100,5 +148,7 @@ ParseResult HttpRequest::parse_header(std::string &header)
     }
     if (!validate_required_headers( ))
         throw (BadRequest);
+    // std::cout << "---------------------------------" <<std::endl;
+    handle_cookies();
     return (OK);
 }


### PR DESCRIPTION
parse Cookie header into std::map, ignore invalid entries